### PR TITLE
setting path in cron is better solution

### DIFF
--- a/update-apacheblocker.sh
+++ b/update-apacheblocker.sh
@@ -59,7 +59,7 @@ DATE=$(date +%Y-%m-%d-%H-%M-%S)
 
 if [ ! -f ${APACHE_CONF}/globalblacklist.conf ] ; then
   #Aborting update
-  echo -e "Subject: Bad bot not installed properly \\n\\n ${CONF_ERROR}\\n" | /usr/sbin/sendmail -t ${EMAIL};
+  echo -e "Subject: Bad bot not installed properly \\n\\n ${CONF_ERROR}\\n" | sendmail -t ${EMAIL};
   exit 1;
 else
   diff <(wget -q -O - ${BLACKLIST_URL}) ${APACHE_CONF}/globalblacklist.conf;
@@ -74,7 +74,7 @@ else
     fi 
     wget ${BLACKLIST_URL} -O ${APACHE_CONF}/globalblacklist.tmp && mv ${APACHE_CONF}/globalblacklist.tmp ${APACHE_CONF}/globalblacklist.conf;
     if [ -f ${APACHE_CONF}/globalblacklist.tmp ] ; then
-      echo -e "Subject: Bad bot updated globalblacklist \\n\\n ${WGET_FAIL}\\n" | /usr/sbin/sendmail -t ${EMAIL};
+      echo -e "Subject: Bad bot updated globalblacklist \\n\\n ${WGET_FAIL}\\n" | sendmail -t ${EMAIL};
       rm -f ${APACHE_CONF}/globalblacklist.tmp;
       exit 1;
     fi
@@ -87,14 +87,14 @@ else
         CURL_RESPONSE_BAD=$(curl -A "masscan" -Isk -o /dev/null -w %{http_code} ${CURL_TEST_PROTOCOL}://${CURL_TEST_URL_NAME} | tr -dc '[:alnum:]')
         CURL_RESPONSE_GOOD=$(curl -A "googlebot" -Isk -o /dev/null -w %{http_code} ${CURL_TEST_PROTOCOL}://${CURL_TEST_URL_NAME} | tr -dc '[:alnum:]')
         if [ $CURL_RESPONSE_BAD != "403" ] || [ $CURL_RESPONSE_GOOD != "200" ] ; then
-          echo -e "Subject: Bad bot CURL FAIL \\n\\n ${CURL_FAIL}\\n" | /usr/sbin/sendmail -t ${EMAIL};
+          echo -e "Subject: Bad bot CURL FAIL \\n\\n ${CURL_FAIL}\\n" | sendmail -t ${EMAIL};
           exit 1;
         fi
       fi
-      echo -e "Subject: Bad bot updated globalblacklist \\n\\n ${UPDATE_SUCCESS}\\n" | /usr/sbin/sendmail -t ${EMAIL};
+      echo -e "Subject: Bad bot updated globalblacklist \\n\\n ${UPDATE_SUCCESS}\\n" | sendmail -t ${EMAIL};
       exit 0;
     else
-      echo -e "Subject: Bad bot update FAIL \\n\\n ${UPDATE_FAIL}\\n" | /usr/sbin/sendmail -t ${EMAIL};
+      echo -e "Subject: Bad bot update FAIL \\n\\n ${UPDATE_FAIL}\\n" | sendmail -t ${EMAIL};
       exit 1;
     fi
   fi


### PR DESCRIPTION
A better solution is for someone to set the path in the cron itself. This location might not be consistent across all OS. 

e.g.

```
# /etc/cron.d/badbot_blockerupdate: crontab entries for the apache-ultimate-bad-bot-blocker updater
#
# Checks for updates to the global blacklist once a day.
#
#
SHELL=/bin/sh
PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin

0 4 * * * root /usr/local/bin/update-apacheblocker.sh
``` 