### PR TITLE
Removing OSO

### DIFF
--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -1033,7 +1033,6 @@ Orisbot
 Ornl_crawler
 Ornl_mercury
 Osis-project.jp
-Oso
 OutclicksBot
 OutfoxBot
 Outfoxmelonbot


### PR DESCRIPTION
Removing as `\bOso\b` will block Micr**oso**ft

e.g:
```
Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 10.0; WOW64; Trident/8.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729; Microsoft Outlook 16.0.6366; ms-office; MSOffice 16)
```