### PR TITLE
Backup cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.{diff,md}]
+trim_trailing_whitespace = false

--- a/update-apacheblocker.sh
+++ b/update-apacheblocker.sh
@@ -71,6 +71,8 @@ else
   else
     if [ ${MAKE_BACKUP} = true ] ; then
       cp "${APACHE_CONF}/globalblacklist.conf" "${APACHE_CONF}/globalblacklist.${DATE}.backup";
+      # Delete backups that are older than 5 days
+      find ${APACHE_CONF} -maxdepth 1 -type f -mtime +5 -name globalblacklist.*.backup -exec rm {} \;
     fi
     wget ${BLACKLIST_URL} -O ${APACHE_CONF}/globalblacklist.tmp && mv ${APACHE_CONF}/globalblacklist.tmp ${APACHE_CONF}/globalblacklist.conf;
     if [ -f ${APACHE_CONF}/globalblacklist.tmp ] ; then

--- a/update-apacheblocker.sh
+++ b/update-apacheblocker.sh
@@ -27,7 +27,7 @@
 # RUN THE UPDATE
 # Here our script runs, pulls the latest update, runs a config test then reloads apache and emails you a notification
 # Place your own valid email address where it says "me@myemail.com"
- 
+
 #Update all environment variables to suit your OS/Apache version.
 
 #Major Apache version e.g. 2.2, 2.4
@@ -46,11 +46,11 @@ TEST_BEFORE_RELOAD=true
 CURL_TEST_AFTER_RELOAD=true
 #Specify if your site uses http or https
 CURL_TEST_PROTOCOL=http
-#domain name to test against. 
+#domain name to test against.
 CURL_TEST_URL_NAME=localhost
 
 SERVER_NAME=$(hostname)
-UPDATE_FAIL="Bad bot failed to update globalblacklist on ${SERVER_NAME}" 
+UPDATE_FAIL="Bad bot failed to update globalblacklist on ${SERVER_NAME}"
 UPDATE_SUCCESS="Bad bot globalblacklist successfully updated on ${SERVER_NAME}"
 CURL_FAIL="Bad bot curl tests have failed on ${SERVER_NAME}."
 WGET_FAIL="Unable to obtain updated globalblacklist. Wget failed on ${SERVER_NAME}."
@@ -71,7 +71,7 @@ else
   else
     if [ ${MAKE_BACKUP} = true ] ; then
       cp "${APACHE_CONF}/globalblacklist.conf" "${APACHE_CONF}/globalblacklist.${DATE}.backup";
-    fi 
+    fi
     wget ${BLACKLIST_URL} -O ${APACHE_CONF}/globalblacklist.tmp && mv ${APACHE_CONF}/globalblacklist.tmp ${APACHE_CONF}/globalblacklist.conf;
     if [ -f ${APACHE_CONF}/globalblacklist.tmp ] ; then
       echo -e "Subject: Bad bot update WGET FAIL \\n\\n ${WGET_FAIL}\\n" | sendmail -t ${EMAIL};


### PR DESCRIPTION
1. One commit to remove some trailing white space.
1. Another to add .editorconfig file. Most editors will automatically remove trailing whitespace with this file in place. It also sets some configs.
1. Finally, one last one that should remove backups that are over 5 days old.