### PR TITLE
Do not block millions of ip

### DIFF
--- a/Apache_2.2/custom.d/blacklist-ips.conf
+++ b/Apache_2.2/custom.d/blacklist-ips.conf
@@ -14,7 +14,7 @@
 
 # This is merely an example and gets auto included as since Version 2.2017.05 introduced on 2017-04-19
 # This file must exist on your system or Apache will fail a reload due to a missing file
-# For all intensive purpose you can delete everything inside this file and leave it
+# For all intents and purposes you can delete everything inside this file and leave it
 # completely blank if you do not want your Apache Blocker to do any blocking of bad IP's
 
 deny from 104.223.37.150
@@ -146,7 +146,7 @@ deny from 93.238.202.44
 # Cyveillance / Qwest Communications / PSINET
 # *******************************************
 # I am extensively researching this subject - appears to be US government involved
-# and also appears to be used by all sorts of law enforcement agencies. For one they 
+# and also appears to be used by all sorts of law enforcement agencies. For one they
 # do not obey robots.txt and continually disguise their User-Agent strings. Time will
 # tell if this is all correct or not.
 # For now see - https://en.wikipedia.org/wiki/Cyveillance
@@ -162,7 +162,7 @@ deny from 93.238.202.44
 # I personally have now unblocked them as image theft is a big problem of mine but if you
 # do want to block Cyveillance you can simply modify the entries in the block below from "0" to "1"
 # Getty Images is one such company who appears to use Cyveillance to help monitor for copyright theft.
-  
+
 # If you really do want to block them change all the 0's below to 1.
 # Use this section at YOUR OWN RISK, you may block some legitimate networks but after many hours of
 # Research this is now the completely updated list of all IP ranges IPV4 and IPV6 owned Qwest Communications
@@ -192,7 +192,7 @@ Allow from 208.71.164.0/22
 # "$\xC9\xE1\xDC\x9B+\x8F\x1C\xE71\x99\xA8\xDB6\x1E#\xBB\x19#Hx\xA7\xFD\x0F9-"
 # and is sometime VERY long. You may have noticed this in your logs.
 # I support research projects and all my servers respond with an error to this type of
-# string so I do not block them but if you want to block just uncomment the following line 
+# string so I do not block them but if you want to block just uncomment the following line
 # or email them asking them not to scan your server. They do respond.
 # Visit http://169.229.3.91/ for more info
 

--- a/Apache_2.4/custom.d/blacklist-ips.conf
+++ b/Apache_2.4/custom.d/blacklist-ips.conf
@@ -14,7 +14,7 @@
 
 # This is merely an example and gets auto included as since Version 2.2017.05 introduced on 2017-04-19
 # This file must exist on your system or Apache will fail a reload due to a missing file
-# For all intensive purpose you can delete everything inside this file and leave it
+# For all intents and purposes you can delete everything inside this file and leave it
 # completely blank if you do not want your Apache Blocker to do any blocking of bad IP's
 
 Require not ip 104.223.37.150
@@ -146,7 +146,7 @@ Require not ip 93.238.202.44
 # Cyveillance / Qwest Communications / PSINET
 # *******************************************
 # I am extensively researching this subject - appears to be US government involved
-# and also appears to be used by all sorts of law enforcement agencies. For one they 
+# and also appears to be used by all sorts of law enforcement agencies. For one they
 # do not obey robots.txt and continually disguise their User-Agent strings. Time will
 # tell if this is all correct or not.
 # For now see - https://en.wikipedia.org/wiki/Cyveillance
@@ -162,7 +162,7 @@ Require not ip 93.238.202.44
 # I personally have now unblocked them as image theft is a big problem of mine but if you
 # do want to allow Cyveillance you can simply modify the entries in the below from "Require not ip" to "Require ip"
 # Getty Images is one such company who appears to use Cyveillance to help monitor for copyright theft.
-  
+
 # Use this section at YOUR OWN RISK, you may block some legitimate networks but after many hours of
 # Research this is now the completely updated list of all IP ranges IPV4 and IPV6 owned Qwest Communications
 # PSINET and Cyveillance

--- a/Apache_2.4/custom.d/blacklist-ips.conf
+++ b/Apache_2.4/custom.d/blacklist-ips.conf
@@ -171,13 +171,13 @@ Require not ip 93.238.202.44
 # Rather implement a comlex Google Re-Captcha to reach sections of your sites and for people to be able
 # to access download links. Google Re-Captcha with images is too complex for any bot.
 
-Require not ip 4.17.135.32/27
-Require not ip 38.0.0.0/8
-Require not ip 63.144.0.0/13
-Require not ip 65.112.0.0/12
-Require not ip 65.192.0.0/11
-Require not ip 65.213.208.128/27
-Require not ip 65.222.176.96/27
-Require not ip 65.222.185.72/29
-Require not ip 206.2.138.0/23
-Require not ip 208.71.164.0/22
+Require ip 4.17.135.32/27
+Require ip 38.0.0.0/8
+Require ip 63.144.0.0/13
+Require ip 65.112.0.0/12
+Require ip 65.192.0.0/11
+Require ip 65.213.208.128/27
+Require ip 65.222.176.96/27
+Require ip 65.222.185.72/29
+Require ip 206.2.138.0/23
+Require ip 208.71.164.0/22


### PR DESCRIPTION
**Non functional change**
.editorconfig automatically removed all the trailing whitespace. I changed wording of a comment slightly.

**Functional change**
Had a customer complain because we were blocking their entire subnet after adding these configs to their server.

Comparing the Apache 2.2 and Apache 2.4 versions of the blacklist-ips.conf, it seems that the ranges at the bottom of this file are allowed in 2.2 version, but denied in the 2.4 version.

I changed to 2.4 version to also allow these ranges. 

@mitchellkrogza I read your comments above where the directives at the bottom of the files are and am not sure if your intent is to block them or allow them. I opted on the allow side, but hope that you will respond to this PR. I can adjust it as necessary.