### PR TITLE
Add single quotes around your file expression

### DIFF
--- a/update-apacheblocker.sh
+++ b/update-apacheblocker.sh
@@ -72,7 +72,7 @@ else
     if [ ${MAKE_BACKUP} = true ] ; then
       cp "${APACHE_CONF}/globalblacklist.conf" "${APACHE_CONF}/globalblacklist.${DATE}.backup";
       # Delete backups that are older than 5 days
-      find ${APACHE_CONF} -maxdepth 1 -type f -mtime +5 -name globalblacklist.*.backup -exec rm {} \;
+      find ${APACHE_CONF} -maxdepth 1 -type f -mtime +5 -name 'globalblacklist.*.backup' -exec rm {} \;
     fi
     wget ${BLACKLIST_URL} -O ${APACHE_CONF}/globalblacklist.tmp && mv ${APACHE_CONF}/globalblacklist.tmp ${APACHE_CONF}/globalblacklist.conf;
     if [ -f ${APACHE_CONF}/globalblacklist.tmp ] ; then


### PR DESCRIPTION
These will stop the shell (bash) expanding wildcards and find command from failing.