### PR TITLE
Added quiet option to wget when downloading globalblacklist

### DIFF
--- a/update-apacheblocker.sh
+++ b/update-apacheblocker.sh
@@ -74,7 +74,7 @@ else
       # Delete backups that are older than 5 days
       find ${APACHE_CONF} -maxdepth 1 -type f -mtime +5 -name 'globalblacklist.*.backup' -exec rm {} \;
     fi
-    wget ${BLACKLIST_URL} -O ${APACHE_CONF}/globalblacklist.tmp && mv ${APACHE_CONF}/globalblacklist.tmp ${APACHE_CONF}/globalblacklist.conf;
+    wget -q ${BLACKLIST_URL} -O ${APACHE_CONF}/globalblacklist.tmp && mv ${APACHE_CONF}/globalblacklist.tmp ${APACHE_CONF}/globalblacklist.conf;
     if [ -f ${APACHE_CONF}/globalblacklist.tmp ] ; then
       echo -e "Subject: Bad bot update WGET FAIL \\n\\n ${WGET_FAIL}\\n" | sendmail -t ${EMAIL};
       rm -f ${APACHE_CONF}/globalblacklist.tmp;


### PR DESCRIPTION
This fixes an issue where wget sends progress to stderr causing issues with wrapper scripts which detect the presence of stderr and produce exit status != 1... Since wget progress is not an error, we shouldn't have update-apacheblocker.sh exemplify as stderr. Furthermore, Knowing the progress of wget in a cron isn't necessary so suppressing output with quiet option causes no objectionable harm.