### PR TITLE
Added adscanner to bad bots

### DIFF
--- a/Apache_2.4/custom.d/globalblacklist.conf
+++ b/Apache_2.4/custom.d/globalblacklist.conf
@@ -176,6 +176,7 @@ BrowserMatchNoCase "(?:\b)Aboundex(?:\b)" bad_bot
 BrowserMatchNoCase "(?:\b)Aboundexbot(?:\b)" bad_bot
 BrowserMatchNoCase "(?:\b)Acunetix(?:\b)" bad_bot
 BrowserMatchNoCase "(?:\b)ADmantX(?:\b)" bad_bot
+BrowserMatchNoCase "(?:\b)adscanner(?:\b)" bad_bot
 BrowserMatchNoCase "(?:\b)AfD-Verbotsverfahren(?:\b)" bad_bot
 BrowserMatchNoCase "(?:\b)AhrefsBot(?:\b)" bad_bot
 BrowserMatchNoCase "(?:\b)AIBOT(?:\b)" bad_bot


### PR DESCRIPTION
Match Mozilla/5.0 (compatible; adscanner/)/1.0 (http://seocompany[dot]store; spider@seocompany[dot]store) as a bad bot.