### PR TITLE
Added AdsTxtCrawlerTP/1.2

### DIFF
--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -4,6 +4,7 @@
 404enemy
 80legs
 ADmantX
+AdsTxtCrawlerTP/1.2
 AIBOT
 ALittle\ Client
 ASPSeek


### PR DESCRIPTION
Annoying bot(s), they usually flood non existent pages trying to enumerate .txt files. They're usually hosted on AWS