### PR TITLE
Trim UA block list for false positives

### DIFF
--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -133,7 +133,6 @@ Ecxi
 EirGrabber
 EroCrawler
 Evil
-Exabot
 Express\ WebPictures
 ExtLinksBot
 Extractor

--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -1,5 +1,4 @@
 01h4x.com
-360Spider
 404checker
 404enemy
 80legs
@@ -180,7 +179,6 @@ HTMLparser
 HTTP::Lite
 HTTrack
 Haansoft
-HaosouSpider
 Harvest
 Havij
 Heritrix
@@ -275,7 +273,6 @@ Meanpathbot
 Mediatoolkitbot
 MegaIndex.ru
 Metauri
-MicroMessenger
 Microsoft\ Data\ Access
 Microsoft\ URL\ Control
 Minefield
@@ -419,7 +416,6 @@ Snapbot
 Snoopy
 SocialRankIOBot
 Sociscraper
-Sogou\ web\ spider
 Sosospider
 Sottopop
 SpaceBison
@@ -563,7 +559,6 @@ clark-crawler
 coccocbot
 cognitiveseo
 com.plumanalytics
-crawl.sogou.com
 crawler.feedback
 crawler4j
 dataforseo.com
@@ -603,7 +598,6 @@ serpstatbot
 sexsearcher
 sitechecker.pro
 siteripz
-sogouspider
 sp_auditbot
 spyfu
 sysscan

--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -303,7 +303,6 @@ NetMechanic
 NetSpider
 NetZIP
 Net\ Vampire
-Netcraft
 Nettrack
 Netvibes
 NextGenSearchBot

--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -62,7 +62,6 @@ Buck
 Buddy
 BuiltBotTough
 BuiltWith
-Bullseye
 BunnySlippers
 BuzzSumo
 CATExplorador

--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -317,7 +317,6 @@ NimbleCrawler
 Nimbostratus
 Ninja
 Nmap
-Not
 Nuclei
 Nutch
 Octopus

--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -225,7 +225,6 @@ Keyword\ Density
 Kinza
 Kozmosbot
 LNSpiderguy
-LWP::Simple
 Lanshanbot
 Larbin
 Leap
@@ -589,8 +588,6 @@ ips-agent
 isitwp.com
 iubenda-radar
 linkdexbot
-lwp-request
-lwp-trivial
 magpie-crawler
 meanpathbot
 mediawords

--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -403,7 +403,6 @@ SentiBot
 SeoSiteCheckup
 SeobilityBot
 Seomoz
-Shodan
 Siphon
 SiteCheckerBotCrawler
 SiteExplorer

--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -413,7 +413,6 @@ SiteSnagger
 SiteSucker
 Site\ Sucker
 Sitebeam
-Siteimprove
 Sitevigil
 SlySearch
 SmartDownload

--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -361,7 +361,6 @@ Psbot
 Pu_iN
 Pump
 PxBroker
-PyCurl
 QueryN\ Metasearch
 Quick-Crawler
 RSSingBot

--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -591,7 +591,6 @@ meanpathbot
 mediawords
 muhstik-scan
 netEstate\ NE\ Crawler
-oBot
 page\ scorer
 pcBrowser
 plumanalytics

--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -227,7 +227,6 @@ Kozmosbot
 LNSpiderguy
 Lanshanbot
 Larbin
-Leap
 LeechFTP
 LeechGet
 LexiBot

--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -313,7 +313,6 @@ Niki-bot
 Nikto
 NimbleCrawler
 Nimbostratus
-Ninja
 Nmap
 Nuclei
 Nutch

--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -277,7 +277,6 @@ Microsoft\ URL\ Control
 Minefield
 Mister\ PiX
 Moblie Safari
-Mojeek
 Mojolicious
 MolokaiBot
 Morfeus\ Fucking\ Scanner

--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -555,7 +555,6 @@ ZoominfoBot
 ZumBot
 ZyBorg
 adscanner
-archive.org_bot
 arquivo-web-crawler
 arquivo.pt
 autoemailspider

--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -489,7 +489,6 @@ Voil
 Voltron
 WASALive-Bot
 WBSearchBot
-WEBDAV
 WISENutbot
 WPScan
 WWW-Collector-E


### PR DESCRIPTION
After 1,5 months of using your UA block list in a production environment of a certain size, we had to make some local alterations to weed out false positives we were encountering. I'm submitting them all here, together with an explanation and justification for each, presented as individual commits in case you feel they need to be cherry-picked.

Do note that we're not using the list "as intended", but rather consume the source list directly to use in HAProxy, where we do case-insensitive sub-string matching against the client's UA. If you feel there's a better (unified) way to make use of this data - such as use word boundaries or case sensitivity or whatnot - I'm all ears.

Thanks for all your hard work!