### PR TITLE
Added WPSec

### DIFF
--- a/_generator_lists/bad-user-agents.list
+++ b/_generator_lists/bad-user-agents.list
@@ -508,6 +508,7 @@ WBSearchBot
 WEBDAV
 WISENutbot
 WPScan
+WPSec
 WWW-Collector-E
 WWW-Mechanize
 WWW::Mechanize


### PR DESCRIPTION
Matching: (compatible; WPSec/1.3; +https://wpsec.com)

Another clone of the Wordpress WPScan online scanner.